### PR TITLE
Remove Auth Service token generation from e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This Step is based on [key-based caching](https://devcenter.bitrise.io/en/builds
 
 ## 🧩 Get started
 
-Add this step directly to your workflow in the [Bitrise Workflow Editor](https://devcenter.bitrise.io/steps-and-workflows/steps-and-workflows-index/).
+Add this step directly to your workflow in the [Bitrise Workflow Editor](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/steps/adding-steps-to-a-workflow.html).
 
 You can also run this step directly with [Bitrise CLI](https://github.com/bitrise-io/bitrise).
 
@@ -46,6 +46,7 @@ Check out [Workflow Recipes](https://github.com/bitrise-io/workflow-recipes#-key
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
 | `verbose` | Enable logging additional information for troubleshooting | required | `false` |
+| `compression_level` | Zstd compression level to control speed / archive size. Set to 1 for fastest option. Valid values are between 1 and 19. Defaults to 3. |  | `3` |
 </details>
 
 <details>
@@ -57,12 +58,11 @@ There are no outputs defined in this step
 
 We welcome [pull requests](https://github.com/bitrise-steplib/bitrise-step-save-dart-cache/pulls) and [issues](https://github.com/bitrise-steplib/bitrise-step-save-dart-cache/issues) against this repository.
 
-For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://devcenter.bitrise.io/bitrise-cli/run-your-first-build/).
+For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://docs.bitrise.io/en/bitrise-ci/bitrise-cli/running-your-first-local-build-with-the-cli.html).
 
 **Note:** this step's end-to-end tests (defined in `e2e/bitrise.yml`) are working with secrets which are intentionally not stored in this repo. External contributors won't be able to run those tests. Don't worry, if you open a PR with your contribution, we will help with running tests and make sure that they pass.
 
 
 Learn more about developing steps:
 
-- [Create your own step](https://devcenter.bitrise.io/contributors/create-your-own-step/)
-- [Testing your Step](https://devcenter.bitrise.io/contributors/testing-and-versioning-your-steps/)
+- [Create your own step](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/developing-your-own-bitrise-step/developing-a-new-step.html)

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -1,12 +1,6 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
-app:
-  envs:
-  # Shared secrets for testing, use a .bitrise.secrets.yml file to define these locally
-  - BITRISEIO_CACHE_SERVICE_URL: $BITRISEIO_CACHE_SERVICE_URL
-  - CACHE_API_CLIENT_SECRET: $CACHE_API_CLIENT_SECRET
-
 workflows:
   test_dart:
     envs:
@@ -14,7 +8,6 @@ workflows:
     - COMMIT: 6210b5dff666ff15fabb66cbfbc51a2b53a3c511
     - FLUTTER_VERSION: 3.13.6
     before_run:
-    - _generate_api_token
     - _setup
     steps:
     - change-workdir:
@@ -81,26 +74,3 @@ workflows:
         - clone_into_dir: ./_tmp
         - branch: $BRANCH
         - commit: $COMMIT
-
-  _generate_api_token:
-    steps:
-    - script:
-        title: Generate API access token
-        description: Generate an expiring API token using $API_CLIENT_SECRET
-        inputs:
-        - content: |
-            #!/bin/env bash
-            set -e
-
-            json_response=$(curl --fail -X POST https://auth.services.bitrise.io/auth/realms/bitrise-services/protocol/openid-connect/token -k \
-                --data "client_id=bitrise-steps" \
-                --data "client_secret=$CACHE_API_CLIENT_SECRET" \
-                --data "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket" \
-                --data "claim_token=eyJhcHBfaWQiOlsiY2FjaGUtc3RlcHMtdGVzdHMiXSwgIm9yZ19pZCI6WyJ0ZXN0LW9yZy1pZCJdLCAiYWJjc19hY2Nlc3NfZ3JhbnRlZCI6WyJ0cnVlIl19" \
-                --data "claim_token_format=urn:ietf:params:oauth:token-type:jwt" \
-                --data "audience=bitrise-services")
-
-            auth_token=$(echo $json_response | jq -r .access_token)
-
-            envman add --key BITRISEIO_ABCS_API_URL --value $BITRISEIO_CACHE_SERVICE_URL --sensitive
-            envman add --key BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN --value $auth_token --sensitive


### PR DESCRIPTION
## Summary
- Remove the `_generate_api_token` utility workflow that requests UMA tokens from `auth.services.bitrise.io`
- Remove all `before_run` references to `_generate_api_token` from test workflows
- Remove now-unused app-level env vars (`CACHE_API_CLIENT_SECRET`, `BITRISEIO_CACHE_SERVICE_URL`, etc.)

**Note:** E2E tests will need `BITRISEIO_ABCS_API_URL` and `BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN` provided through a different mechanism for the cache steps to authenticate.

## Test plan
- [ ] Verify e2e tests still pass with the new token provisioning mechanism